### PR TITLE
Various cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
         run: make cfn
 
       - name: Run tests
-        run: make test
+        run: make ci-test

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ dummy:
 	poetry run python job_scheduler/dummy_service/main.py
 
 redis:
-	docker compose up -d redis
+	docker-compose up -d redis
 
 image:
 	docker build . -t  job-scheduler:$(PROJECT_VERSION) --force-rm

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help:
 clean:
 	rm -rf .pytest_cache cdk.out .venv .coverage
 
-test:
+test: redis
 	poetry run pytest --cov=job_scheduler
 
 api:
@@ -42,7 +42,7 @@ dummy:
 	poetry run python job_scheduler/dummy_service/main.py
 
 redis:
-	docker run -d --name redis -p 6379:6379 redis:6.0-alpine
+	docker compose up -d redis
 
 image:
 	docker build . -t  job-scheduler:$(PROJECT_VERSION) --force-rm

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ help:
 clean:
 	rm -rf .pytest_cache cdk.out .venv .coverage
 
+ci-test:
+	poetry run pytest --cov=job_scheduler
+
 test: redis
 	poetry run pytest --cov=job_scheduler
 
@@ -42,7 +45,7 @@ dummy:
 	poetry run python job_scheduler/dummy_service/main.py
 
 redis:
-	docker-compose up -d redis
+	docker compose up -d redis
 
 image:
 	docker build . -t  job-scheduler:$(PROJECT_VERSION) --force-rm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     redis:
         image: redis:6.0-alpine
         ports:
-            - "6379"
+            - "6379:6379"
 
     scheduler:
         image: job-scheduler:${IMAGE_TAG}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def n_jobs(schedule: Schedule):
     return _make_n_jobs
 
 
-@pytest.yield_fixture(scope="session")
+@pytest.fixture(scope="session")
 def event_loop(request):
     """
     We need to override the event_loop fixture such that it is of the


### PR DESCRIPTION
- Exposes compose redis over localhost
- make test has a dependency on make redis
- make redis uses compose to start the container
- Removes deprecated yield_fixture