### PR TITLE
Fixes duplicate poetry installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.9-alpine
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=on \
-    POETRY_VIRTUALENVS_CREATE=false \
     APP_USER=app
 
 RUN apk update && \
@@ -20,7 +19,7 @@ COPY poetry.lock pyproject.toml ./
 RUN poetry install --no-dev --no-root
 
 COPY README.rst Makefile ./
-ADD job_scheduler job_scheduler
+COPY job_scheduler job_scheduler
 RUN poetry install --no-dev
 
 CMD ["make api"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,6 @@ services:
             APP_DATABASE_URL: redis://redis
             APP_DEV_MODE: 1
 
-
     dummy-endpoint:
         image: job-scheduler:${IMAGE_TAG}
         command: make dummy


### PR DESCRIPTION
When installing dependencies, then adding source, then installing the source, the dependencies were getting installed twice. This seems to be an issue with how poetry manages installing packages in the main Python location. Letting poetry use virtualenvs fixes the issue.