### PR TITLE
Refactors the CDK App Stack

### DIFF
--- a/cdk/resources.py
+++ b/cdk/resources.py
@@ -1,0 +1,91 @@
+import aws_cdk.aws_elasticloadbalancingv2 as elbv2
+import aws_cdk.aws_route53 as route53
+import aws_cdk.aws_route53_targets as route53_targets
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_elasticache as ec
+from aws_cdk import core as cdk
+
+
+class RedisCluster(cdk.Construct):
+    # Create a single node ElastiCache cluster and resources:
+    # The subnet group is used to choose a subnet and IP addresses for the
+    # cache nodes
+    # The security group creates a network ACL to prevent all inbound and
+    # outbound connections. Later allow connections from the Fargate Service.
+
+    def __init__(self, scope: cdk.Construct, id: str, *, vpc: ec2.Vpc, **kwargs):
+        super().__init__(scope, id)
+
+        self.subnet_group = ec.CfnSubnetGroup(
+            self,
+            "ElastiCacheSubnetGroup",
+            subnet_ids=[ps.subnet_id for ps in vpc.private_subnets],
+            description="ElastiCache Subnet Group",
+        )
+        self.security_group = ec2.SecurityGroup(
+            self, "ElastiCacheSecurityGroup", vpc=vpc, allow_all_outbound=False
+        )
+        self.redis = ec.CfnCacheCluster(
+            self,
+            "ElastiCacheCluster",
+            cache_node_type="cache.t2.micro",
+            auto_minor_version_upgrade=True,
+            engine="redis",
+            num_cache_nodes=1,
+            cache_subnet_group_name=self.subnet_group.ref,
+            vpc_security_group_ids=[self.security_group.security_group_id],
+        )
+        self.endpoint_address = self.redis.attr_redis_endpoint_address
+
+
+class DNS(cdk.Construct):
+    # Create a hosted zone for this project, under which multiple subdomains
+    # may live i.e. api.job-scheduler... app.job-scheduler... For this to
+    # work the parent zone must exist already and have a valid registered
+    # domain name. This allows the API to be hit via a 'friendly' web URL
+    # such as api.job-scheduler.uriel.globuscs.info
+    # Docs:
+    # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-routing-traffic-for-subdomains.html#dns-routing-traffic-for-subdomains-creating-records
+    def __init__(
+        self,
+        scope: cdk.Construct,
+        id: str,
+        *,
+        lb: elbv2.ApplicationLoadBalancer,
+        **kwargs,
+    ):
+        super().__init__(scope, id)
+        parent_zone_name = kwargs.get("parent_zone_name", "uriel.globuscs.info")
+        parent_zone_id = kwargs.get("parent_zone_id", "Z07538033GFYDX485PZSC")
+        project_subdomain_name = kwargs.get("project_subdomain_name", "job-scheduler")
+        api_subdomain_name = kwargs.get("api_subdomain_name", "api")
+        zone_name = f"{project_subdomain_name}.{parent_zone_name}"
+
+        zone = route53.PublicHostedZone(self, "HostedZone", zone_name=zone_name)
+        parent_zone = route53.HostedZone.from_hosted_zone_attributes(
+            self,
+            "ParentHostedZone",
+            zone_name=parent_zone_name,
+            hosted_zone_id=parent_zone_id,
+        )
+        # Create a record in the parent zone telling it to forward traffic for
+        # the job-scheduler domain to the new zone
+        route53.ZoneDelegationRecord(
+            self,
+            "NS",
+            zone=parent_zone,
+            record_name=project_subdomain_name,
+            name_servers=zone.hosted_zone_name_servers or [],
+        )
+        route53.ARecord(
+            self,
+            "ARecord",
+            zone=zone,
+            target=route53.RecordTarget.from_alias(
+                route53_targets.LoadBalancerTarget(lb)
+            ),
+            record_name=api_subdomain_name,
+            ttl=cdk.Duration.seconds(300),
+        )
+
+        self.api_domain = f"{api_subdomain_name}.{zone_name}"

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -1,12 +1,10 @@
 import aws_cdk.aws_ecs as ecs
 import aws_cdk.aws_elasticloadbalancingv2 as elbv2
-import aws_cdk.aws_route53 as route53
-import aws_cdk.aws_route53_targets as route53_targets
 from aws_cdk import aws_ec2 as ec2
-from aws_cdk import aws_elasticache as ec
 from aws_cdk import core as cdk
 from aws_cdk.aws_logs import RetentionDays
-from aws_cdk.core import Duration, Tags
+
+from cdk.resources import DNS, RedisCluster
 
 # from aws_cdk import aws_ecr as ecr
 
@@ -15,33 +13,9 @@ class JobSchedulerStack(cdk.Stack):
     def __init__(self, scope: cdk.Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        Tags.of(self).add("StackName", construct_id)
+        cdk.Tags.of(self).add("StackName", construct_id)
         vpc = ec2.Vpc(self, "VPC", max_azs=2)
-
-        # Create a single node ElastiCache cluster and resources:
-        # The subnet group is used to choose a subnet and IP addresses for the
-        # cache nodes
-        # The security group creates a network ACL to prevent all inbound and
-        # outbound connections
-        cache_subnet_group = ec.CfnSubnetGroup(
-            self,
-            "ElasticCacheSubnetGroup",
-            subnet_ids=[ps.subnet_id for ps in vpc.private_subnets],
-            description="ElasticCache Subnet Group",
-        )
-        ec_security_group = ec2.SecurityGroup(
-            self, "ElastiCacheSG", vpc=vpc, allow_all_outbound=False
-        )
-        redis = ec.CfnCacheCluster(
-            self,
-            "Redis",
-            cache_node_type="cache.t2.micro",
-            auto_minor_version_upgrade=True,
-            engine="redis",
-            num_cache_nodes=1,
-            cache_subnet_group_name=cache_subnet_group.ref,
-            vpc_security_group_ids=[ec_security_group.security_group_id],
-        )
+        redis = RedisCluster(self, "RedisCluster", vpc=vpc)
 
         # Create the image repository that will hold our private images
         # Notice that this creates a bootstrap problem - we need the registry
@@ -70,7 +44,7 @@ class JobSchedulerStack(cdk.Stack):
             environment={
                 "APP_API_HOST": "0.0.0.0",
                 "APP_API_PORT": "8000",
-                "APP_DATABASE_URL": f"redis://{redis.attr_redis_endpoint_address}",
+                "APP_DATABASE_URL": f"redis://{redis.endpoint_address}",
             },
             logging=ecs.LogDrivers.aws_logs(
                 stream_prefix="api", log_retention=RetentionDays.ONE_WEEK
@@ -81,8 +55,8 @@ class JobSchedulerStack(cdk.Stack):
             image=ecs.ContainerImage.from_asset("."),
             command=["make", "scheduler"],
             environment={
-                "APP_DATABASE_URL": f"redis://{redis.attr_redis_endpoint_address}",
-                "APP_BROKER_URL": f"redis://{redis.attr_redis_endpoint_address}",
+                "APP_DATABASE_URL": f"redis://{redis.endpoint_address}",
+                "APP_BROKER_URL": f"redis://{redis.endpoint_address}",
             },
             logging=ecs.LogDrivers.aws_logs(
                 stream_prefix="scheduler", log_retention=RetentionDays.ONE_WEEK
@@ -93,8 +67,8 @@ class JobSchedulerStack(cdk.Stack):
             image=ecs.ContainerImage.from_asset("."),
             command=["make", "runner"],
             environment={
-                "APP_DATABASE_URL": f"redis://{redis.attr_redis_endpoint_address}",
-                "APP_BROKER_URL": f"redis://{redis.attr_redis_endpoint_address}",
+                "APP_DATABASE_URL": f"redis://{redis.endpoint_address}",
+                "APP_BROKER_URL": f"redis://{redis.endpoint_address}",
             },
             logging=ecs.LogDrivers.aws_logs(
                 stream_prefix="runner", log_retention=RetentionDays.ONE_WEEK
@@ -114,7 +88,7 @@ class JobSchedulerStack(cdk.Stack):
             desired_count=1,
             circuit_breaker={"rollback": True},
         )
-        service.connections.allow_to(ec_security_group, ec2.Port.tcp(6379))
+        service.connections.allow_to(redis.security_group, ec2.Port.tcp(6379))
 
         # Create a LoadBalancer which makes the API container publicly
         # accessible. The LB listens for connections on port 80 and forwards
@@ -139,51 +113,16 @@ class JobSchedulerStack(cdk.Stack):
             ),
         )
 
-        # Create a hosted zone for this project, under which multiple subdomains
-        # may live i.e. api.job-scheduler... app.job-scheduler... For this to
-        # work the parent zone must exist already and have a valid registered
-        # domain name. This allows the API to be hit via a 'friendly' web URL
-        # such as api.job-scheduler.uriel.globuscs.info
-        # Docs:
-        # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-routing-traffic-for-subdomains.html#dns-routing-traffic-for-subdomains-creating-records
-        parent_zone_name = "uriel.globuscs.info"
-        parent_zone_id = "Z07538033GFYDX485PZSC"
-        project_subdomain_name = "job-scheduler"
-        api_subdomain_name = "api"
-        zone_name = f"{project_subdomain_name}.{parent_zone_name}"
-
-        zone = route53.PublicHostedZone(self, "HostedZone", zone_name=zone_name)
-        parent_zone = route53.HostedZone.from_hosted_zone_attributes(
-            self,
-            "ParentHostedZone",
-            zone_name=parent_zone_name,
-            hosted_zone_id=parent_zone_id,
-        )
-        # Create a record in the parent zone telling it to forward traffic for
-        # the job-scheduler domain to the new zone
-        route53.ZoneDelegationRecord(
-            self,
-            "NS",
-            zone=parent_zone,
-            record_name=project_subdomain_name,
-            name_servers=zone.hosted_zone_name_servers or [],
-        )
-        arecord = route53.ARecord(
-            self,
-            "ARecord",
-            zone=zone,
-            target=route53.RecordTarget.from_alias(
-                route53_targets.LoadBalancerTarget(lb)
-            ),
-            record_name=api_subdomain_name,
-            ttl=Duration.seconds(300),
-        )
+        # Configure the DNS records for the project. This is optional, but if
+        # used we can publish a static URL for the service rather than relying
+        # on the gross-looking ALB's DNS name
+        dns = DNS(self, "Route53DNS", lb=lb)
 
         cdk.CfnOutput(
             self,
-            "FriendlyLBDNSName",
-            value=f"{api_subdomain_name}.{zone_name}",
-            description="Friendly DNS Name for the ALB",
+            "APISubdomain",
+            value=dns.api_domain,
+            description="ALB Hostname for the API",
         )
         cdk.CfnOutput(
             self,


### PR DESCRIPTION
CDK best practice is to create re-usable Constructs where possible. This PR refactors the standalone components of the app into their own Construct which is then imported and used in the Stack. The new Constructs are `RedisCluster` and `DNS`, where `RedisCluster` is responsible for creating a Redis Cluster and `DNS` creates the app's hosted zone and DNS records.